### PR TITLE
Let wide tables extend past the text column in centered layout

### DIFF
--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,7 +1,13 @@
 import imageViewerPlugin from './img-viewer'
 import blockCopyPlugin from './block-copy'
 import graphvizRendererPlugin from './graphviz-renderer'
+import tableColumnsPlugin from './table-columns'
 import { usePlugin } from '@/core/plugin'
 export { initPlugins } from '@/core/plugin'
 
-usePlugin([blockCopyPlugin, imageViewerPlugin, graphvizRendererPlugin])
+usePlugin([
+  blockCopyPlugin,
+  imageViewerPlugin,
+  graphvizRendererPlugin,
+  tableColumnsPlugin,
+])

--- a/src/plugins/table-columns.ts
+++ b/src/plugins/table-columns.ts
@@ -1,0 +1,39 @@
+import throttle from 'lodash.throttle'
+
+// Shrinks the columns of a table that overflows its box: each cell's minimum
+// width becomes the smaller of the theme's 10rem and the column's one-line
+// width, so short columns stop padding out to 10rem. Tables that fit keep
+// the theme's layout.
+function fitTables(content: HTMLElement) {
+  content.querySelectorAll('table').forEach(table => {
+    const cells = [...table.querySelectorAll('td, th')] as HTMLElement[]
+    cells.forEach(cell => (cell.style.minWidth = ''))
+    if (table.scrollWidth <= table.clientWidth) return
+    const rows = [...table.rows]
+    cells.forEach(cell => (cell.style.minWidth = '0'))
+    table.style.whiteSpace = 'nowrap'
+    const widths = rows.map(row =>
+      [...row.cells].map(cell => cell.getBoundingClientRect().width),
+    )
+    table.style.whiteSpace = ''
+    rows.forEach(row =>
+      [...row.cells].forEach((cell, i) => {
+        const natural = Math.max(...widths.map(w => w[i] ?? 0))
+        cell.style.minWidth = `min(10rem, ${Math.ceil(natural)}px)`
+      }),
+    )
+  })
+}
+
+export default function TableColumnsPlugin({ event }) {
+  let content: HTMLElement
+  event.on('contentRendered', (rendered: HTMLElement) => {
+    content = rendered
+    // The content is attached to the document and laid out after this event.
+    requestAnimationFrame(() => fitTables(content))
+  })
+  window.addEventListener(
+    'resize',
+    throttle(() => content && fitTables(content), 100),
+  )
+}

--- a/src/style/index.less
+++ b/src/style/index.less
@@ -113,6 +113,14 @@ body.md-reader {
           }
         }
         .theme(); // markdown theme
+        // Wrapping only between words keeps table layout from collapsing a
+        // column narrower than its longest word when the table-columns
+        // plugin removes the minimum width.
+        td,
+        th {
+          word-break: normal;
+          overflow-wrap: break-word;
+        }
         h1,
         h2,
         h3,

--- a/src/style/index.less
+++ b/src/style/index.less
@@ -89,7 +89,8 @@ body.md-reader {
 
     &__body {
       min-height: 100vh;
-      padding-left: @side-width;
+      --side-width: @side-width;
+      padding-left: var(--side-width);
       transition: padding 0.3s;
       .md-reader__markdown-content {
         padding: 30px 70px 40px;
@@ -98,6 +99,18 @@ body.md-reader {
         transition: max-width 0.1s;
         &.centered {
           max-width: 900px;
+          overflow-x: visible;
+          // A wide table grows past both edges of the text column, staying
+          // centered on it, until it reaches the page padding.
+          > table {
+            width: max-content;
+            min-width: 100%;
+            // 140px is the column's 70px horizontal padding on both sides.
+            max-width: calc(100vw - var(--side-width) - 140px);
+            position: relative;
+            left: 50%;
+            translate: -50%;
+          }
         }
         .theme(); // markdown theme
         h1,
@@ -207,7 +220,7 @@ body.md-reader {
         border-color: transparent;
       }
       &__body {
-        padding-left: 0px;
+        --side-width: 0px;
       }
       &__btn--side-expand {
         transform: translateX(0);
@@ -248,7 +261,7 @@ body.md-reader {
         border-color: transparent;
       }
       &__body {
-        padding-left: 0px;
+        --side-width: 0px;
       }
       &__btn--side-expand {
         transform: translateX(0);


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

In centered mode the content column is capped at 900–1600px, so a wide table is squeezed into that width and scrolls horizontally even when the window has plenty of room beside it.

With this change a table wider than the column grows symmetrically past both of its edges, staying centered on the column, until it reaches the page's 70px side padding; past that it scrolls as before. Tables that fit the column are unchanged and still sit at the text's left edge. Nested tables and the non-centered layout are untouched.

A top-level table in `.centered` gets `width: max-content` with `min-width: 100%`, so it never shrinks below the column but can exceed it, and `left: 50%; translate: -50%` keeps it centered on the column. Its `max-width` is the viewport minus the sidebar and the page padding, which needs the sidebar width as a custom property since that value changes with `side-collapsed` and the narrow-screen media query. The column also needs `overflow-x: visible` so it doesn't clip the overhang.

It also adds a small `table-columns` plugin: when a table overflows its box, each column's minimum width becomes the smaller of the theme's 10rem and its one-line width, on render and on resize. Short columns shrink to their content, longer text still wraps no narrower than 10rem, and tables that fit are untouched.

Before, in a 1920px window with the sidebar open (cropped out here):

![Before: the table is clipped at the column edge and scrolls](https://raw.githubusercontent.com/ahalekelly/md-reader/0148753af9b46a7c44b64e0c352e6c55694374d0/before.png)

After:

![After: the table extends past both edges of the text column](https://raw.githubusercontent.com/ahalekelly/md-reader/0148753af9b46a7c44b64e0c352e6c55694374d0/after.png)
